### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 R utility functions for Arpa ER air quality data
 
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.21062.svg)](http://dx.doi.org/10.5281/zenodo.21062)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.21062.svg)](https://doi.org/10.5281/zenodo.21062)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,7 @@
   <div class="contents col-md-9">
     
 <p>R utility functions for Arpa ER air quality data</p>
-<p><a href="http://dx.doi.org/10.5281/zenodo.21062"><img src="https://zenodo.org/badge/doi/10.5281/zenodo.21062.svg" alt="DOI"></a></p>
+<p><a href="https://doi.org/10.5281/zenodo.21062"><img src="https://zenodo.org/badge/doi/10.5281/zenodo.21062.svg" alt="DOI"></a></p>
 
   </div>
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well. Accordingly, this PR updates all DOI links.

Cheers!